### PR TITLE
Adds ability to select a given sheet/tab by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ parser.parse().then((items) => {
 parser.parse(spreadsheetId).then((items) => {
   // items should be [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6},{"a":7,"b":8,"c":9}]
 })
+
+
+// 4. You can also pass  the name of specific sheet/tab if you want to get that instead of the first one.
+parser.parse(spreadsheetId, "Sheet2").then((items) => {
+  // items should be from the second sheet!
+})
 ```
 You can use any of the three methods you want!
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ parser.parse(spreadsheetId).then((items) => {
 })
 
 
-// 4. You can also pass  the name of specific sheet/tab if you want to get that instead of the first one.
-parser.parse(spreadsheetId, "Sheet2").then((items) => {
+// 4. You can also pass  the name of specific sheet if you want to get that instead of the first one.
+parser.parse(spreadsheetId, 'Sheet2').then((items) => {
   // items should be from the second sheet!
 })
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "public-google-sheets-parser",
-  "version": "1.0.22",
+  "version": "1.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,9 @@ const isBrowser = typeof require === 'undefined'
 const fetch = isBrowser ? window.fetch : require('node-fetch')
 
 class PublicGoogleSheetsParser {
-  constructor (spreadsheetId, tabName) {
+  constructor (spreadsheetId, sheetName) {
     this.id = spreadsheetId
-    this.tab = tabName
+    this.sheetName = sheetName
   }
 
   getSpreadsheetDataUsingFetch () {
@@ -12,12 +12,12 @@ class PublicGoogleSheetsParser {
     // It cannot be used unless everyone has been given read permission.
     // It must be a spreadsheet document with a header, as in the example document below.
     // spreadsheet document for example: https://docs.google.com/spreadsheets/d/10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps/edit#gid=1719755213
-    // Sheet/Tab selection from: https://stackoverflow.com/a/44592363/1649917
+    // Sheet selection from: https://stackoverflow.com/a/44592363/1649917
 
     if (!this.id) return null
     let url = `https://docs.google.com/spreadsheets/d/${this.id}/gviz/tq?`
-    if (this.tab) {
-      url = url.concat(`sheet=${this.tab}`)
+    if (this.sheetName) {
+      url = url.concat(`sheet=${this.sheetName}`)
     }
 
     return fetch(url)
@@ -56,9 +56,9 @@ class PublicGoogleSheetsParser {
     return rows
   }
 
-  async parse (spreadsheetId, tabName) {
+  async parse (spreadsheetId, sheetName) {
     if (spreadsheetId) this.id = spreadsheetId
-    if (tabName) this.tab = tabName
+    if (sheetName) this.sheetName = sheetName
 
     if (!this.id) throw new Error('SpreadsheetId is required.')
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,18 +2,25 @@ const isBrowser = typeof require === 'undefined'
 const fetch = isBrowser ? window.fetch : require('node-fetch')
 
 class PublicGoogleSheetsParser {
-  constructor (spreadsheetId) {
+  constructor (spreadsheetId, tabName) {
     this.id = spreadsheetId
+    this.tab = tabName
   }
 
   getSpreadsheetDataUsingFetch () {
-    if (!this.id) return null
-
     // Read data from the first sheet of the target document.
     // It cannot be used unless everyone has been given read permission.
     // It must be a spreadsheet document with a header, as in the example document below.
     // spreadsheet document for example: https://docs.google.com/spreadsheets/d/10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps/edit#gid=1719755213
-    return fetch(`https://docs.google.com/spreadsheets/d/${this.id}/gviz/tq?`)
+    // Sheet/Tab selection from: https://stackoverflow.com/a/44592363/1649917
+
+    if (!this.id) return null
+    let url = `https://docs.google.com/spreadsheets/d/${this.id}/gviz/tq?`
+    if (this.tab) {
+      url = url.concat(`sheet=${this.tab}`)
+    }
+
+    return fetch(url)
       .then((r) => r.ok ? r.text() : null)
       .catch((_) => null)
   }
@@ -49,8 +56,9 @@ class PublicGoogleSheetsParser {
     return rows
   }
 
-  async parse (spreadsheetId) {
+  async parse (spreadsheetId, tabName) {
     if (spreadsheetId) this.id = spreadsheetId
+    if (tabName) this.tab = tabName
 
     if (!this.id) throw new Error('SpreadsheetId is required.')
 

--- a/test/index.js
+++ b/test/index.js
@@ -62,3 +62,20 @@ test('parse method should return array even spreadsheetId is invalid', async (t)
 
   t.end()
 })
+
+test('should get first tab by default if none is specified', async (t) => {
+  const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
+  const result = await parser.parse(spreadsheetId)
+  const expected = [{ a: 1, b: 2, c: 3 }, { a: 4, b: 5, c: 6 }, { a: 7, b: 8, c: 9 }]
+  t.deepEqual(result, expected)
+  t.end()
+})
+
+test('should get 2nd tab if specified', async (t) => {
+  const spreadsheetId = '1wdU-Cf7Kn5ZvhcvRePOoL10urdTA6TWGndBSKDAiYbQ'
+  const tabName = 'Sheet2'
+  const result = await parser.parse(spreadsheetId, tabName)
+  const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
+  t.deepEqual(result, expected)
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ test('parse method should return array even spreadsheetId is invalid', async (t)
   t.end()
 })
 
-test('should get first tab by default if none is specified', async (t) => {
+test('should get first sheet by default if none is specified', async (t) => {
   const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
   const result = await parser.parse(spreadsheetId)
   const expected = [{ a: 1, b: 2, c: 3 }, { a: 4, b: 5, c: 6 }, { a: 7, b: 8, c: 9 }]
@@ -71,10 +71,10 @@ test('should get first tab by default if none is specified', async (t) => {
   t.end()
 })
 
-test('should get 2nd tab if specified', async (t) => {
+test('should get 2nd sheet if specified', async (t) => {
   const spreadsheetId = '1wdU-Cf7Kn5ZvhcvRePOoL10urdTA6TWGndBSKDAiYbQ'
-  const tabName = 'Sheet2'
-  const result = await parser.parse(spreadsheetId, tabName)
+  const sheetName = 'Sheet2'
+  const result = await parser.parse(spreadsheetId, sheetName)
   const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
   t.deepEqual(result, expected)
   t.end()


### PR DESCRIPTION
This does a really simple check to see whether a user has specified a sheet name. If so, the script will then get that sheet instead of the sheet. However, if no sheet name is specified the script will behave exactly as before and fetch the first sheet by default.