### PR TITLE
change reference to fetch to relative

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11,7 +11,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 const isBrowser = typeof require === 'undefined';
 const fetch = isBrowser ?
 /* istanbul ignore next */
-window.fetch : require('./fetch');
+window.fetch : require('../src/fetch');
 
 let PublicGoogleSheetsParser = /*#__PURE__*/function () {
   function PublicGoogleSheetsParser(spreadsheetId, sheetName) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const isBrowser = typeof require === 'undefined'
-const fetch = isBrowser ? /* istanbul ignore next */window.fetch : require('./fetch')
+const fetch = isBrowser ? /* istanbul ignore next */window.fetch : require('../src/fetch')
 
 class PublicGoogleSheetsParser {
   constructor (spreadsheetId, sheetName) {


### PR DESCRIPTION
We had been getting this error when including the dist/index.js version of this library, which we needed to get the babelified/transpiled version:

```
gitpod /workspace/leaflet-environmental-layers $ grunt build
Running "browserify:dist" (browserify) task
>> Error: Can't walk dependency graph: Cannot find module './fetch' from '/workspace/leaflet-environmental-layers/node_modules/public-google-sheets-parser/dist/index.js'
>>     required by /workspace/leaflet-environmental-layers/node_modules/public-google-sheets-parser/dist/index.js
Warning: Error running grunt-browserify. Use --force to continue.
```

I realized that fetch was a relative path but this is calculated from /src/ originally, but /dist/ in the dist file. So I changed it and it should work in both now!

https://github.com/fureweb-com/public-google-sheets-parser/blob/049dc620444d6029e0d8c1bd99c3f366aabff32b/dist/index.js#L14