### PR TITLE
Support sheet ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ parser.parse(spreadsheetId, { sheetId: '784337977' }).then((items) => {
 // Sheet name or sheet ID can also be passed during instantiation:
 const parser = new PublicGoogleSheetsParser(spreadsheetId, { sheetId: '784337977'})
 parser.parse().then((items) => {
-  // items should be [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6},{"a":7,"b":8,"c":9}]
+  // items should be [{"a":10,"b":20,"c":30},{"a":40,"b":50,"c":60},{"a":70,"b":80,"c":90}]
 })
 
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ parser.parse(spreadsheetId, 'Sheet2').then((items) => {
   // items should be [{"a":10,"b":20,"c":30},{"a":40,"b":50,"c":60},{"a":70,"b":80,"c":90}]
 })
 // ...or as an object (since v1.3.0) that specifies the sheet's name or ID. If both are provided, sheet ID is used:
-parser.parse(spreadsheetId, { sheetId: '123456789' }).then((items) => {
+parser.parse(spreadsheetId, { sheetId: '784337977' }).then((items) => {
   // items should be [{"a":10,"b":20,"c":30},{"a":40,"b":50,"c":60},{"a":70,"b":80,"c":90}]
 })
 
 // Sheet name or sheet ID can also be passed during instantiation:
-const parser = new PublicGoogleSheetsParser(spreadsheetId, { sheetId: '123456789'})
+const parser = new PublicGoogleSheetsParser(spreadsheetId, { sheetId: '784337977'})
 parser.parse().then((items) => {
   // items should be [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6},{"a":7,"b":8,"c":9}]
 })

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ It is a simple and **zero dependency** parser that helps you use public Google s
 
 The document to be used must be a Google Sheets document in the 'public' state and have a header in the first row. (e.g. [Google sheets for example](https://docs.google.com/spreadsheets/d/10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps/edit#gid=1839148703))
 
-**You can specify the sheet name to get a data. (Since v1.1.0)**
+**You can optionally specify the sheet's tab name to get data from that specific sheet. (Since v1.1.0)**
+**You can optionally specify the sheet's GID to get data from that specific sheet. (Since v1.3.0)**
 
 It does not work in browsers where the [fetch API](https://caniuse.com/fetch) is not available.
 
@@ -48,13 +49,13 @@ const PublicGoogleSheetsParser = require('public-google-sheets-parser')
 
 const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
 
-// 1. You can pass spreadsheetId when parser instantiation
+// 1. You can pass spreadsheetId when instantiating the parser:
 const parser = new PublicGoogleSheetsParser(spreadsheetId)
 parser.parse().then((items) => {
   // items should be [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6},{"a":7,"b":8,"c":9}]
 })
 
-// 2. You can change spreadsheetId on runtime
+// 2. You can change spreadsheetId on runtime:
 const anotherSpreadsheetId = '1oCgY0UHHRQ95snw7URFpOOL_DQcVG_wydlOoGiTof5E'
 parser.id = anotherSpreadsheetId
 parser.parse().then((items) => {
@@ -67,16 +68,28 @@ parser.parse().then((items) => {
   */
 })
 
-// 3. You can pass the spreadsheet ID when call parse method.
+// 3. You can pass the spreadsheet ID when call parse method:
 parser.parse(spreadsheetId).then((items) => {
   // items should be [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6},{"a":7,"b":8,"c":9}]
 })
 
 
-// 4. You can also pass the name of specific sheet to get.
+// 4. You can also retrieve a specific sheet to get by either passing the sheet name as a string (since v1.1.0):
 parser.parse(spreadsheetId, 'Sheet2').then((items) => {
   // items should be [{"a":10,"b":20,"c":30},{"a":40,"b":50,"c":60},{"a":70,"b":80,"c":90}]
 })
+// ...or as an object (since v1.3.0) that specifies the sheet's name or ID. If both are provided, sheet ID is used:
+parser.parse(spreadsheetId, { sheetId: '123456789' }).then((items) => {
+  // items should be [{"a":10,"b":20,"c":30},{"a":40,"b":50,"c":60},{"a":70,"b":80,"c":90}]
+})
+
+// Sheet name or sheet ID can also be passed during instantiation:
+const parser = new PublicGoogleSheetsParser(spreadsheetId, { sheetId: '123456789'})
+parser.parse().then((items) => {
+  // items should be [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6},{"a":7,"b":8,"c":9}]
+})
+
+
 ```
 
 You can use any of the 4 methods you want!

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,6 +20,13 @@ let PublicGoogleSheetsParser = /*#__PURE__*/function () {
     this.id = spreadsheetId;
     this.parseSheetInfo(sheetInfo);
   }
+  /**
+   * Parses the given object or string into sheetName and/or sheetId.
+   * If a string is given, sheetName is set.
+   * If an object is given, its sheetId and sheetName properties are set.
+    * @param sheetInfo
+   */
+
 
   _createClass(PublicGoogleSheetsParser, [{
     key: "parseSheetInfo",
@@ -27,6 +34,7 @@ let PublicGoogleSheetsParser = /*#__PURE__*/function () {
       if (sheetInfo) {
         if (typeof sheetInfo === 'string') {
           this.sheetName = sheetInfo;
+          this.sheetId = null;
         } else if (typeof sheetInfo === 'object') {
           this.sheetName = sheetInfo.sheetName;
           this.sheetId = sheetInfo.sheetId;

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,14 +14,26 @@ const fetch = isBrowser ?
 window.fetch : require('../src/fetch');
 
 let PublicGoogleSheetsParser = /*#__PURE__*/function () {
-  function PublicGoogleSheetsParser(spreadsheetId, sheetName) {
+  function PublicGoogleSheetsParser(spreadsheetId, sheetInfo) {
     _classCallCheck(this, PublicGoogleSheetsParser);
 
     this.id = spreadsheetId;
-    this.sheetName = sheetName;
+    this.parseSheetInfo(sheetInfo);
   }
 
   _createClass(PublicGoogleSheetsParser, [{
+    key: "parseSheetInfo",
+    value: function parseSheetInfo(sheetInfo) {
+      if (sheetInfo) {
+        if (typeof sheetInfo === 'string') {
+          this.sheetName = sheetInfo;
+        } else if (typeof sheetInfo === 'object') {
+          this.sheetName = sheetInfo.sheetName;
+          this.sheetId = sheetInfo.sheetId;
+        }
+      }
+    }
+  }, {
     key: "getSpreadsheetDataUsingFetch",
     value: function getSpreadsheetDataUsingFetch() {
       // Read data from the first sheet of the target document.
@@ -31,7 +43,9 @@ let PublicGoogleSheetsParser = /*#__PURE__*/function () {
       if (!this.id) return null;
       let url = `https://docs.google.com/spreadsheets/d/${this.id}/gviz/tq?`;
 
-      if (this.sheetName) {
+      if (this.sheetId) {
+        url = url.concat(`gid=${this.sheetId}`);
+      } else if (this.sheetName) {
         url = url.concat(`sheet=${this.sheetName}`);
       }
 
@@ -81,9 +95,9 @@ let PublicGoogleSheetsParser = /*#__PURE__*/function () {
   }, {
     key: "parse",
     value: function () {
-      var _parse = _asyncToGenerator(function* (spreadsheetId, sheetName) {
+      var _parse = _asyncToGenerator(function* (spreadsheetId, sheetInfo) {
         if (spreadsheetId) this.id = spreadsheetId;
-        if (sheetName) this.sheetName = sheetName;
+        if (sheetInfo) this.parseSheetInfo(sheetInfo);
         if (!this.id) throw new Error('SpreadsheetId is required.');
         const spreadsheetResponse = yield this.getSpreadsheetDataUsingFetch();
         if (spreadsheetResponse === null) return [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-google-sheets-parser",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Get JSONArray from public google sheets with using only spreadsheetId",
   "scripts": {
     "build:dist": "npx babel ./src/index.js --out-file ./dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,28 @@ const isBrowser = typeof require === 'undefined'
 const fetch = isBrowser ? /* istanbul ignore next */window.fetch : require('../src/fetch')
 
 class PublicGoogleSheetsParser {
-  constructor (spreadsheetId, sheetName) {
+  constructor (spreadsheetId, sheetInfo) {
     this.id = spreadsheetId
-    this.sheetName = sheetName
+    this.parseSheetInfo(sheetInfo);
+  }
+
+  /**
+   * Parses the given object or string into sheetName and/or sheetId.
+   * If a string is given, sheetName is set.
+   * If an object is given, its sheetId and sheetName properties are set.
+    * @param sheetInfo
+   */
+  parseSheetInfo (sheetInfo) {
+    if (sheetInfo) {
+      if (typeof sheetInfo === 'string') {
+        this.sheetName = sheetInfo;
+      }
+      else if (typeof sheetInfo === 'object') {
+        this.sheetName = sheetInfo.sheetName;
+        this.sheetId = sheetInfo.sheetId;
+      }
+    }
+
   }
 
   getSpreadsheetDataUsingFetch () {
@@ -14,7 +33,10 @@ class PublicGoogleSheetsParser {
     // spreadsheet document for example: https://docs.google.com/spreadsheets/d/10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps/edit#gid=1719755213
     if (!this.id) return null
     let url = `https://docs.google.com/spreadsheets/d/${this.id}/gviz/tq?`
-    if (this.sheetName) {
+    if (this.sheetId) {
+      url = url.concat(`gid=${this.sheetId}`)
+    }
+    else if (this.sheetName) {
       url = url.concat(`sheet=${this.sheetName}`)
     }
 
@@ -54,9 +76,9 @@ class PublicGoogleSheetsParser {
     return rows
   }
 
-  async parse (spreadsheetId, sheetName) {
+  async parse (spreadsheetId, sheetInfo) {
     if (spreadsheetId) this.id = spreadsheetId
-    if (sheetName) this.sheetName = sheetName
+    if (sheetInfo) this.parseSheetInfo(sheetInfo);
 
     if (!this.id) throw new Error('SpreadsheetId is required.')
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ class PublicGoogleSheetsParser {
     if (sheetInfo) {
       if (typeof sheetInfo === 'string') {
         this.sheetName = sheetInfo;
+        this.sheetId = null;
       }
       else if (typeof sheetInfo === 'object') {
         this.sheetName = sheetInfo.sheetName;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const fetch = isBrowser ? /* istanbul ignore next */window.fetch : require('../s
 class PublicGoogleSheetsParser {
   constructor (spreadsheetId, sheetInfo) {
     this.id = spreadsheetId
-    this.parseSheetInfo(sheetInfo);
+    this.parseSheetInfo(sheetInfo)
   }
 
   /**
@@ -16,15 +16,13 @@ class PublicGoogleSheetsParser {
   parseSheetInfo (sheetInfo) {
     if (sheetInfo) {
       if (typeof sheetInfo === 'string') {
-        this.sheetName = sheetInfo;
-        this.sheetId = null;
-      }
-      else if (typeof sheetInfo === 'object') {
-        this.sheetName = sheetInfo.sheetName;
-        this.sheetId = sheetInfo.sheetId;
+        this.sheetName = sheetInfo
+        this.sheetId = null
+      } else if (typeof sheetInfo === 'object') {
+        this.sheetName = sheetInfo.sheetName
+        this.sheetId = sheetInfo.sheetId
       }
     }
-
   }
 
   getSpreadsheetDataUsingFetch () {
@@ -36,8 +34,7 @@ class PublicGoogleSheetsParser {
     let url = `https://docs.google.com/spreadsheets/d/${this.id}/gviz/tq?`
     if (this.sheetId) {
       url = url.concat(`gid=${this.sheetId}`)
-    }
-    else if (this.sheetName) {
+    } else if (this.sheetName) {
       url = url.concat(`sheet=${this.sheetName}`)
     }
 
@@ -79,7 +76,7 @@ class PublicGoogleSheetsParser {
 
   async parse (spreadsheetId, sheetInfo) {
     if (spreadsheetId) this.id = spreadsheetId
-    if (sheetInfo) this.parseSheetInfo(sheetInfo);
+    if (sheetInfo) this.parseSheetInfo(sheetInfo)
 
     if (!this.id) throw new Error('SpreadsheetId is required.')
 

--- a/test/base.js
+++ b/test/base.js
@@ -67,7 +67,7 @@ class Test {
       t.end()
     })
 
-    test('should get 2nd sheet if specified', async (t) => {
+    test('should get 2nd sheet if name is specified', async (t) => {
       const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
       const sheetName = 'Sheet2'
       const result = await this.parser.parse(spreadsheetId, sheetName)
@@ -136,6 +136,41 @@ class Test {
         { no: 15, date: '2022-12-25', name: '크리스마스' }
       ]
       t.deepEqual(resultOf2022, expectedOf2022)
+      t.end()
+    })
+
+    test('should get 2nd sheet if sheet ID specified', async (t) => {
+      const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
+      const sheetInfo = { sheetId: '934929616' }
+      const result = await this.parser.parse(spreadsheetId, sheetInfo)
+      const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
+      t.deepEqual(result, expected)
+      t.end()
+    })
+
+    test('should parse properly after changing sheetId at runtime', async (t) => {
+      const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
+      const firstSheetId = '0'
+      const secondSheetId = '934929616'
+
+      const firstResult = await this.parser.parse(spreadsheetId, { sheetId: firstSheetId })
+      const firstExpected = [{ a: 1, b: 2, c: 3 }, { a: 4, b: 5, c: 6 }, { a: 7, b: 8, c: 9 }]
+      t.deepEqual(firstResult, firstExpected)
+
+      const secondResult = await this.parser.parse(spreadsheetId, { sheetId: secondSheetId })
+      const secondExpected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
+      t.deepEqual(secondResult, secondExpected)
+      t.end()
+    })
+
+    test('should parse properly if both sheetName and sheetId are given', async (t) => {
+      const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
+      const sheetName = '2022'
+      const sheetId = '934929616'
+
+      const result = await this.parser.parse(spreadsheetId, { sheetId: sheetId, sheetName: sheetName })
+      const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
+      t.deepEqual(result, expected)
       t.end()
     })
 

--- a/test/base.js
+++ b/test/base.js
@@ -141,7 +141,7 @@ class Test {
 
     test('should get 2nd sheet if sheet ID specified', async (t) => {
       const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
-      const sheetInfo = { sheetId: '934929616' }
+      const sheetInfo = { sheetId: '784337977' }
       const result = await this.parser.parse(spreadsheetId, sheetInfo)
       const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
       t.deepEqual(result, expected)
@@ -151,7 +151,7 @@ class Test {
     test('should parse properly after changing sheetId at runtime', async (t) => {
       const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
       const firstSheetId = '0'
-      const secondSheetId = '934929616'
+      const secondSheetId = '784337977'
 
       const firstResult = await this.parser.parse(spreadsheetId, { sheetId: firstSheetId })
       const firstExpected = [{ a: 1, b: 2, c: 3 }, { a: 4, b: 5, c: 6 }, { a: 7, b: 8, c: 9 }]
@@ -165,8 +165,8 @@ class Test {
 
     test('should parse properly if both sheetName and sheetId are given', async (t) => {
       const spreadsheetId = '10WDbAPAY7Xl5DT36VuMheTPTTpqx9x0C5sDCnh4BGps'
-      const sheetName = '2022'
-      const sheetId = '934929616'
+      const sheetName = 'Sheet2'
+      const sheetId = '784337977'
 
       const result = await this.parser.parse(spreadsheetId, { sheetId: sheetId, sheetName: sheetName })
       const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
@@ -196,6 +196,8 @@ class Test {
 
     test('should return expected array even if there are empty cell', async (t) => {
       this.parser.id = '1hAT59kWFcDSNs9X0puWbylioEIhVnzUtHz6YhYQZ5cw'
+      this.parser.sheetName = null;
+      this.parser.sheetId = null;
       const actualArray = await this.parser.parse()
       const expectedArray = [
         { a: 1, b: 2, c: 3 },

--- a/test/base.js
+++ b/test/base.js
@@ -168,7 +168,7 @@ class Test {
       const sheetName = 'Sheet2'
       const sheetId = '784337977'
 
-      const result = await this.parser.parse(spreadsheetId, { sheetId: sheetId, sheetName: sheetName })
+      const result = await this.parser.parse(spreadsheetId, { sheetId, sheetName })
       const expected = [{ a: 10, b: 20, c: 30 }, { a: 40, b: 50, c: 60 }, { a: 70, b: 80, c: 90 }]
       t.deepEqual(result, expected)
       t.end()
@@ -196,8 +196,8 @@ class Test {
 
     test('should return expected array even if there are empty cell', async (t) => {
       this.parser.id = '1hAT59kWFcDSNs9X0puWbylioEIhVnzUtHz6YhYQZ5cw'
-      this.parser.sheetName = null;
-      this.parser.sheetId = null;
+      this.parser.sheetName = null
+      this.parser.sheetId = null
       const actualArray = await this.parser.parse()
       const expectedArray = [
         { a: 1, b: 2, c: 3 },


### PR DESCRIPTION
This PR adds support for optionally passing a a sheet's ID to fetch a specific sheet in a Google Spreadsheet.

It maintains backwards compatibility by checking if a string is passed as the second argument to either the constructor or .parse() and if so, treats it as the sheetName.

To pass a sheetId instead, the second parameter can instead be an object:
`{ sheetId: '123456789' }`
It also supports passing the sheetName within the object:
`{ sheetName: 'My Sheet }`
If both are provided, it uses the sheetId:
`{ sheetId: '123456789', sheetName: 'My Sheet' } // will use sheetId`

I've added tests, built the dist/index.js, and updated the README.md

Bumped the version to 1.3.0

NOTE: While I followed @cheveedodd suggestion to us an object as the parameter, if you would prefer to instead just take an optional third argument for sheetId (i.e. parser.parse(spreadSheetId, null, sheetId) I am happy to make that change!

Also let me know if there are any other changes you'd like to see. Thanks!