### PR TITLE
Convert date to original formatted string

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42,6 +42,11 @@ let PublicGoogleSheetsParser = /*#__PURE__*/function () {
       }
     }
   }, {
+    key: "isDate",
+    value: function isDate(date) {
+      return date && typeof date === 'string' && /Date\((\d+),(\d+),(\d+)\)/.test(date);
+    }
+  }, {
     key: "getSpreadsheetDataUsingFetch",
     value: function getSpreadsheetDataUsingFetch() {
       // Read data from the first sheet of the target document.
@@ -72,7 +77,7 @@ let PublicGoogleSheetsParser = /*#__PURE__*/function () {
       return rows.map(({
         c: row
       }) => this.normalizeRow(row)).map(row => row.reduce((p, c, i) => c.v !== null && c.v !== undefined ? Object.assign(p, {
-        [header[i]]: c.v
+        [header[i]]: this.isDate(c.v) ? c.f ?? c.v : c.v
       }) : p, {}));
     }
   }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-google-sheets-parser",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Get JSONArray from public google sheets with using only spreadsheetId",
   "scripts": {
     "build:dist": "npx babel ./src/index.js --out-file ./dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const isBrowser = typeof require === 'undefined'
 const fetch = isBrowser ? /* istanbul ignore next */window.fetch : require('../src/fetch')
-
 class PublicGoogleSheetsParser {
   constructor (spreadsheetId, sheetInfo) {
     this.id = spreadsheetId
@@ -23,6 +22,10 @@ class PublicGoogleSheetsParser {
         this.sheetId = sheetInfo.sheetId
       }
     }
+  }
+
+  isDate (date) {
+    return date && typeof date === 'string' && /Date\((\d+),(\d+),(\d+)\)/.test(date)
   }
 
   getSpreadsheetDataUsingFetch () {
@@ -50,7 +53,7 @@ class PublicGoogleSheetsParser {
   applyHeaderIntoRows (header, rows) {
     return rows
       .map(({ c: row }) => this.normalizeRow(row))
-      .map((row) => row.reduce((p, c, i) => (c.v !== null && c.v !== undefined) ? Object.assign(p, { [header[i]]: c.v }) : p, {}))
+      .map((row) => row.reduce((p, c, i) => (c.v !== null && c.v !== undefined) ? Object.assign(p, { [header[i]]: this.isDate(c.v) ? c.f ?? c.v : c.v }) : p, {}))
   }
 
   getItems (spreadsheetResponse) {

--- a/test/base.js
+++ b/test/base.js
@@ -220,6 +220,18 @@ class Test {
 
       t.end()
     })
+
+    test('should return date string when date exists in cell', (t) => {
+      const givenHeader = ['a', 'b', 'c']
+      const givenRows = [
+        { c: [{ v: 1, f: '1' }, { v: 'Date(2024,0,1)', f: '2024-01-01' }, { v: 'Date(2024,11,1)', f: '2024-12-01' }] },
+      ]
+
+      const result = this.parser.applyHeaderIntoRows(givenHeader, givenRows)
+      const expected = [{ a: 1, b: '2024-01-01', c: '2024-12-01' }]
+      t.deepEqual(result, expected)
+      t.end()
+    })
   }
 }
 


### PR DESCRIPTION
If a date is entered in Google Sheets, such as 2024-01-01, the response from the server will look like this Date(2024,0,1).

For values entered as dates in a spreadsheet like this, I want the accompanying formatted string to be displayed as it is.

Also, It resolves #34